### PR TITLE
docs: add pull request workflow guidance

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+## Summary
+
+<!-- What was changed? Keep this concise and specific. -->
+
+## Why
+
+<!-- Why is this change needed? Link the issue when applicable. -->
+
+## Testing
+
+<!-- How was this tested? Include commands, manual checks, or "Not run" with a reason. -->
+
+## Screenshots
+
+<!-- Required for UI changes. Use "N/A" if no UI changed. -->
+
+## PR Checklist
+
+- [ ] This PR is intentionally small and focused.
+- [ ] The change is ideally within 100-400 lines changed, or the larger scope is justified.
+- [ ] The PR title follows Conventional Commits, for example `feat: add source explorer`.
+- [ ] Related issue is linked when applicable.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+# Project Workflow Instructions
+
+## Pull Requests
+
+Work through small pull requests. Prefer one focused change per PR.
+
+- Avoid broad PRs like "Implemented everything".
+- Prefer focused PRs such as "Add query diagnostics model" or "Add evaluation dashboard page".
+- Ideal PR size is 100-400 lines changed.
+- If a PR is larger, explain why it could not be split cleanly.
+
+Every PR must include:
+
+- `Summary`: what changed.
+- `Why`: why the change is needed.
+- `Testing`: how it was tested.
+- `Screenshots`: required when UI changed, otherwise `N/A`.
+
+## Commits
+
+Use Conventional Commits for commit messages and PR titles.
+
+Examples:
+
+- `feat: add audio file import`
+- `fix: handle missing ffmpeg binary`
+- `docs: add architecture overview`
+- `test: add transcription job unit tests`
+- `refactor: extract whisper service interface`
+- `ci: add GitHub Actions build pipeline`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,59 @@
+# Contributing
+
+## Pull Request Size
+
+Work through small pull requests. A PR should represent one focused, reviewable change.
+
+Bad PR:
+
+- Implemented everything
+
+Good PRs:
+
+- Add transcription job model
+- Add ffmpeg service abstraction
+- Add basic file import screen
+- Add export to TXT
+
+Ideal PR size:
+
+- 100-400 lines changed
+
+Larger PRs are acceptable only when the scope cannot be split cleanly. In that case, explain why in the PR description.
+
+## Pull Request Description
+
+Every PR should include:
+
+```md
+## Summary
+
+What was changed.
+
+## Why
+
+Why this change is needed.
+
+## Testing
+
+How it was tested.
+
+## Screenshots
+
+If UI changed.
+```
+
+## Conventional Commits
+
+Use Conventional Commits for commit messages and PR titles.
+
+Examples:
+
+- `feat: add audio file import`
+- `fix: handle missing ffmpeg binary`
+- `docs: add architecture overview`
+- `test: add transcription job unit tests`
+- `refactor: extract whisper service interface`
+- `ci: add GitHub Actions build pipeline`
+
+This keeps history readable and supports changelogs and releases later.


### PR DESCRIPTION
## Summary

- Added a GitHub pull request template with required Summary, Why, Testing, and Screenshots sections.
- Added `CONTRIBUTING.md` with small-PR guidance and Conventional Commit examples.
- Added `AGENTS.md` so project workflow rules are visible for future AI-assisted work.

## Why

Issues are now being used as a public backlog, so PRs should also stay reviewable and consistent. This documents the expected workflow: small focused PRs, clear PR descriptions, screenshots for UI changes, and Conventional Commits for cleaner history and future changelogs/releases.

## Testing

Not run. Documentation and GitHub template changes only.

## Screenshots

N/A. No UI changed.